### PR TITLE
Fix path bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode/
 
 # C extensions
 *.so

--- a/src/main/python/pybuilder_docker/__init__.py
+++ b/src/main/python/pybuilder_docker/__init__.py
@@ -13,6 +13,7 @@ from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
 from pybuilder.pluginhelper.external_command import ExternalCommandResult
 from pybuilder.reactor import Reactor
 
+from pathlib import Path
 
 def _exec_cmd(
         project: Project, logger: Logger, reactor: Reactor,
@@ -99,24 +100,25 @@ def _docker_build_stages(project: Project, logger: Logger, reactor: Reactor, dis
 def _generate_dockerfile(project: Project, logger: Logger, reactor: Reactor, dist_dir: str) -> None:
     dist_file = project.get_property("docker_package_dist_file", f"{project.name}-{project.version}.tar.gz")
     prepare_env_cmd = project.get_property("docker_package_prepare_env_cmd",
-                                           "echo 'empty prepare_env_cmd installing into python'"),
+                                           "echo 'empty prepare_env_cmd installing into python'")
     package_cmd = project.get_property("docker_package_package_cmd", f"pip install {dist_file}")
 
     setup_script = os.path.join(dist_dir, "Dockerfile")
+    logger.debug(f"Prepare Env CMD: {prepare_env_cmd}")
+    logger.debug(f"Package CMD: {package_cmd}")
     with open(setup_script, "w") as setup_file:
         setup_file.write(f"FROM pyb-temp-{project.name}:{project.version}\n"
                          f"MAINTAINER {project.get_property('docker_package_image_maintainer', 'anonymous')}\n"
-                         f"COPY ${dist_file} .\n"
-                         f"RUN ${prepare_env_cmd}\n"
-                         f"RUN ${package_cmd}\n")
+                         f"COPY {dist_file} .\n"
+                         f"RUN {prepare_env_cmd}\n"
+                         f"RUN {package_cmd}\n")
     os.chmod(setup_script, 0o755)
 
 
 def _copy_dist_package(project: Project, logger: Logger, reactor: Reactor, dist_dir: str) -> None:
-    dist_file_path = project.expand_path(
-        _make_folder(project, "$dir_dist", 'dist'),
-        project.get_property("docker_package_dist_file", f"{project.name}-{project.version}.tar.gz")
-    )
+    dist_file_path = Path(_make_folder(project, "$dir_dist", 'dist')) / project.get_property("docker_package_dist_file", f"{project.name}-{project.version}.tar.gz")
+    logger.debug(f"Dist file path {dist_file_path}")
+    logger.debug(f"Copying to: {dist_dir}")
     shutil.copy2(dist_file_path, dist_dir)
 
 
@@ -207,7 +209,7 @@ def _docker_tag_and_push_image(project: Project, logger: Logger, reactor: Reacto
 
 
 def _generate_artifact_manifest(project: Project, logger: Logger, reactor: Reactor, registry_path: str) -> None:
-    artifact_path = project.expand_path(_make_folder(project, '$dir_target'), 'artifact.json')
+    artifact_path = Path(_make_folder(project, '$dir_target')) / 'artifact.json'
     with open(artifact_path, 'w') as target:
         artifact_manifest = {
             'artifact-type': 'container',


### PR DESCRIPTION
These are some fixes I had to do to make it work with Pybuilder 0.12.

1) The code which generates the Dockerfile had some '$' characters hanging around. Also a stray ',' cause the a Tuple to be interpolated instead of a str.
2) There was an issue with _make_folder and project.expand_path in combination concatenating the absolute path twice. I just replaced this with pathlib path joining.

Not sure if you want to keep this codebase going forward? 